### PR TITLE
fix: Handle distribution identifier changes in Dafny 3.13/4.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        dafny: [3.0.0, 3.8.1, 3.13.1, 4.0.0, nightly-2023-02-13-14bc57f, nightly-latest]
+        dafny: [3.0.0, 3.8.1, 3.13.1, 4.0.0, nightly-2023-02-28-80a0e49, nightly-latest]
         # Windows 2.3.0 requires mono
         include:
           - os: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        dafny: [3.0.0, 3.7.3, 3.8.1, nightly-2023-02-13-14bc57f, nightly-latest]
+        dafny: [3.0.0, 3.7.3, 3.8.1, 4.0.0, nightly-2023-02-13-14bc57f, nightly-latest]
         # Windows 2.3.0 requires mono
         include:
           - os: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        dafny: [3.0.0, 3.7.3, 3.8.1, 4.0.0, nightly-2023-02-13-14bc57f, nightly-latest]
+        dafny: [3.0.0, 3.8.1, 3.13.1, 4.0.0, nightly-2023-02-13-14bc57f, nightly-latest]
         # Windows 2.3.0 requires mono
         include:
           - os: macos-latest

--- a/dist/index.js
+++ b/dist/index.js
@@ -6730,7 +6730,8 @@ async function installDotnetTool(toolName, version) {
 // Export functions for testing
 exports.dafnyURL = dafnyURL;
 exports.getDistribution = getDistribution;
-exports.latestNightlyVersionFromDotnetToolSearch = latestNightlyVersionFromDotnetToolSearch;
+exports.latestNightlyVersionFromDotnetToolSearch =
+  latestNightlyVersionFromDotnetToolSearch;
 
 async function dafnyURL(version, distribution) {
   const versionPath = version.startsWith("nightly") ? "nightly" : `v${version}`;
@@ -6754,7 +6755,7 @@ async function latestNightlyVersion() {
       `dotnet tool command failed (exitCode ${exitCode}):\n${stderr}"`
     );
   }
-  return latestNightlyVersionFromDotnetToolSearch(stdout)
+  return latestNightlyVersionFromDotnetToolSearch(stdout);
 }
 
 function latestNightlyVersionFromDotnetToolSearch(output) {
@@ -6776,8 +6777,8 @@ function latestNightlyVersionFromDotnetToolSearch(output) {
     .map((versionLine) => versionLine.trimStart().split(" ")[0]);
 
   const nightlies = versions.filter((l) => l.includes("nightly"));
-  const dates = nightlies.map(nightly => {
-    const date = new Date(nightly.split('-').slice(2, 5).join('-'))
+  const dates = nightlies.map((nightly) => {
+    const date = new Date(nightly.split("-").slice(2, 5).join("-"));
     return { nightly, date };
   });
   dates.sort((a, b) => (a.date < b.date ? 1 : -1));
@@ -6790,14 +6791,41 @@ function latestNightlyVersionFromDotnetToolSearch(output) {
   return version;
 }
 
+function versionToNumeric(version) {
+  // Also copied and modified from dafny-lang/ide-vscode.
+  // Switching to dotnet tool install would avoid having to do this...
+  const numbers = version.split('.').map(x => Number.parseInt(x));
+  return ((numbers[0] * 1000) + (numbers[1] ?? 0)) * 1000 + (numbers[2] ?? 0);
+}
+
 function getDistribution(platform, version) {
-  return platform === "darwin" // Osx
-    ? version == "2.3.0"
-      ? "osx-10.14.1"
-      : "osx-10.14.2"
-    : platform === "win32" // windows
-    ? "win"
-    : "ubuntu-16.04"; // Everything else is linux...
+  // Also copied and modified from dafny-lang/ide-vscode.
+
+  // Since every nightly published after this edit will be configured in the post-3.12 fashion, and this script
+  // fetches the latest nightly, it's safe to just condition this on 'nightly' and not 'nightly-date' for a date
+  // after a certain point.
+  const post312 = versionToNumeric(version) >= versionToNumeric('3.13');
+  if(post312) {
+    switch(platform) {
+    case 'win32':
+      return 'windows-2019';
+    case 'darwin':
+      return 'macos-11';
+    default:
+      return 'ubuntu-20.04';
+    }
+  } else {
+    switch(platform) {
+    case 'win32':
+      return 'win';
+    case 'darwin':
+      return version == "2.3.0"
+        ? "osx-10.14.1"
+        : "osx-10.14.2";
+    default:
+      return 'ubuntu-16.04';
+    }
+  }
 }
 
 })();

--- a/dist/index.js
+++ b/dist/index.js
@@ -6794,8 +6794,8 @@ function latestNightlyVersionFromDotnetToolSearch(output) {
 function versionToNumeric(version) {
   // Also copied and modified from dafny-lang/ide-vscode.
   // Switching to dotnet tool install would avoid having to do this...
-  const numbers = version.split('.').map(x => Number.parseInt(x));
-  return ((numbers[0] * 1000) + (numbers[1] ?? 0)) * 1000 + (numbers[2] ?? 0);
+  const numbers = version.split(".").map((x) => Number.parseInt(x));
+  return (numbers[0] * 1000 + (numbers[1] ?? 0)) * 1000 + (numbers[2] ?? 0);
 }
 
 function getDistribution(platform, version) {
@@ -6804,26 +6804,26 @@ function getDistribution(platform, version) {
   // Since every nightly published after this edit will be configured in the post-3.12 fashion, and this script
   // fetches the latest nightly, it's safe to just condition this on 'nightly' and not 'nightly-date' for a date
   // after a certain point.
-  const post312 = versionToNumeric(version) >= versionToNumeric('3.13');
-  if(post312) {
-    switch(platform) {
-    case 'win32':
-      return 'windows-2019';
-    case 'darwin':
-      return 'macos-11';
-    default:
-      return 'ubuntu-20.04';
+  const post312 =
+    version.includes("nightly") ||
+    versionToNumeric(version) >= versionToNumeric("3.13");
+  if (post312) {
+    switch (platform) {
+      case "win32":
+        return "windows-2019";
+      case "darwin":
+        return "macos-11";
+      default:
+        return "ubuntu-20.04";
     }
   } else {
-    switch(platform) {
-    case 'win32':
-      return 'win';
-    case 'darwin':
-      return version == "2.3.0"
-        ? "osx-10.14.1"
-        : "osx-10.14.2";
-    default:
-      return 'ubuntu-16.04';
+    switch (platform) {
+      case "win32":
+        return "win";
+      case "darwin":
+        return version == "2.3.0" ? "osx-10.14.1" : "osx-10.14.2";
+      default:
+        return "ubuntu-16.04";
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -103,12 +103,37 @@ function latestNightlyVersionFromDotnetToolSearch(output) {
   return version;
 }
 
+function versionToNumeric(version) {
+  // Also copied and modified from dafny-lang/ide-vscode.
+  // Switching to dotnet tool install would avoid having to do this...
+  const numbers = version.split(".").map((x) => Number.parseInt(x));
+  return (numbers[0] * 1000 + (numbers[1] ?? 0)) * 1000 + (numbers[2] ?? 0);
+}
+
 function getDistribution(platform, version) {
-  return platform === "darwin" // Osx
-    ? version == "2.3.0"
-      ? "osx-10.14.1"
-      : "osx-10.14.2"
-    : platform === "win32" // windows
-    ? "win"
-    : "ubuntu-16.04"; // Everything else is linux...
+  // Also copied and modified from dafny-lang/ide-vscode.
+
+  // Since every nightly published after this edit will be configured in the post-3.12 fashion, and this script
+  // fetches the latest nightly, it's safe to just condition this on 'nightly' and not 'nightly-date' for a date
+  // after a certain point.
+  const post312 = versionToNumeric(version) >= versionToNumeric("3.13");
+  if (post312) {
+    switch (platform) {
+      case "win32":
+        return "windows-2019";
+      case "darwin":
+        return "macos-11";
+      default:
+        return "ubuntu-20.04";
+    }
+  } else {
+    switch (platform) {
+      case "win32":
+        return "win";
+      case "darwin":
+        return version == "2.3.0" ? "osx-10.14.1" : "osx-10.14.2";
+      default:
+        return "ubuntu-16.04";
+    }
+  }
 }

--- a/index.js
+++ b/index.js
@@ -116,7 +116,9 @@ function getDistribution(platform, version) {
   // Since every nightly published after this edit will be configured in the post-3.12 fashion, and this script
   // fetches the latest nightly, it's safe to just condition this on 'nightly' and not 'nightly-date' for a date
   // after a certain point.
-  const post312 = versionToNumeric(version) >= versionToNumeric("3.13");
+  const post312 =
+    version.includes("nightly") ||
+    versionToNumeric(version) >= versionToNumeric("3.13");
   if (post312) {
     switch (platform) {
       case "win32":

--- a/test/setup-dafny-action.js
+++ b/test/setup-dafny-action.js
@@ -101,12 +101,18 @@ Versions:
 describe("getDistribution", () => {
   // https://nodejs.org/docs/latest/api/os.html#os_os_platform
   [
+    ["darwin", "4.0.0", "macos-11"],
+    ["darwin", "3.13.1", "macos-11"],
     ["darwin", "3.8.1", "osx-10.14.2"],
     ["darwin", "2.3.0", "osx-10.14.1"],
+    ["win32", "4.0.0", "windows-2019"],
+    ["win32", "3.13.1", "windows-2019"],
     ["win32", "3.8.1", "win"],
     ["win32", "2.3.0", "win"],
 
     // Everything else is treated a ubuntu linux
+    ["freebsd", "4.0.0", "ubuntu-20.04"],
+    ["freebsd", "3.13.1", "ubuntu-20.04"],
     ["aix", "3.8.1", "ubuntu-16.04"],
     ["freebsd", "3.8.1", "ubuntu-16.04"],
     ["linux", "3.8.1", "ubuntu-16.04"],


### PR DESCRIPTION
Dafny simplified the distribution identifiers in 3.13, and the VS Code extension updated its logic to account for it. This PR applies the same logic (pretty literally - I copied and modified again :).

We badly need to find a way to share this logic, or (my preference) standardize on using `dotnet tool install` for distributing Dafny instead.