### PR TITLE
Version constraint on .NET

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,7 @@ runs:
   - uses: actions/setup-node@v4
     with:
       node-version: 16
-  - run: |
-      echo $INPUT_DAFNY-VERSION
-      echo ${{ inputs.dafny-version }}
-      node dist/index.js
+  - run: node dist/index.js
     shell: bash
     env:
       INPUT_DAFNY-VERSION: ${{ inputs.dafny-version }}

--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,9 @@ runs:
     with:
       node-version: 16
   - run: |
-      echo $INPUT_DAFNY_VERSION
+      echo $INPUT_DAFNY-VERSION
       echo ${{ inputs.dafny-version }}
       node dist/index.js
     shell: bash
     env:
-      INPUT_DAFNY_VERSION: ${{ inputs.dafny-version }}
+      INPUT_DAFNY-VERSION: ${{ inputs.dafny-version }}

--- a/action.yml
+++ b/action.yml
@@ -18,3 +18,4 @@ runs:
     with:
       node-version: 16
   - run: node dist/index.js
+    shell: bash

--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,12 @@ inputs:
     required: true
     default: "3.1.0"
 runs:
-  using: "node16"
-  main: "dist/index.js"
+  using: "composite"
+  steps:
+  - uses: actions/setup-dotnet@v4
+    with:
+      dotnet-version: '6.0.x'
+  - uses: actions/setup-node@v4
+    with:
+      node-version: 16
+  - run: node dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ runs:
       node-version: 16
   - run: node dist/index.js
     shell: bash
-    env:
-      INPUT_DAFNY_VERSION: ${{ inputs.dafny-version }}
+    with:
+      dafny-version: ${{ inputs.dafny-version }}

--- a/action.yml
+++ b/action.yml
@@ -19,3 +19,5 @@ runs:
       node-version: 16
   - run: node dist/index.js
     shell: bash
+    env:
+      INPUT_DAFNY_VERSION: ${{ inputs.dafny-version }}

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,10 @@ runs:
   - uses: actions/setup-node@v4
     with:
       node-version: 16
-  - run: node dist/index.js
+  - run: |
+      echo $INPUT_DAFNY_VERSION
+      echo ${{ inputs.dafny-version }}
+      node dist/index.js
     shell: bash
-    with:
-      dafny-version: ${{ inputs.dafny-version }}
+    env:
+      INPUT_DAFNY_VERSION: ${{ inputs.dafny-version }}


### PR DESCRIPTION
Enforces version constraint on .NET so that runners don't use too new a version of .NET (macos arm64 runners will at the moment).