### PR TITLE
Absolute path to access index.js

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
   - uses: actions/setup-node@v4
     with:
       node-version: 16
-  - run: node ${{ github.workspace }}/dist/index.js
+  - run: node ${{ github.action_path }}/dist/index.js
     shell: bash
     env:
       INPUT_DAFNY-VERSION: ${{ inputs.dafny-version }}

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
   - uses: actions/setup-node@v4
     with:
       node-version: 16
-  - run: node ${{ github.action_path }}/dist/index.js
+  - run: node $GITHUB_ACTION_PATH/dist/index.js
     shell: bash
     env:
       INPUT_DAFNY-VERSION: ${{ inputs.dafny-version }}

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
   - uses: actions/setup-node@v4
     with:
       node-version: 16
-  - run: node dist/index.js
+  - run: node ${{ github.workspace }}/dist/index.js
     shell: bash
     env:
       INPUT_DAFNY-VERSION: ${{ inputs.dafny-version }}


### PR DESCRIPTION
@josecorella is hitting the following error from using v1.7.1 within an MPL workflow

```
2024-07-15T16:37:48.1742150Z ##[group]Run node dist/index.js
2024-07-15T16:37:48.1742380Z [36;1mnode dist/index.js[0m
2024-07-15T16:37:48.1774930Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
2024-07-15T16:37:48.1775170Z env:
2024-07-15T16:37:48.1775300Z   DOTNET_CLI_TELEMETRY_OPTOUT: 1
2024-07-15T16:37:48.1775490Z   DOTNET_NOLOGO: 1
2024-07-15T16:37:48.1775640Z   DOTNET_ROOT: /var/root/.dotnet
2024-07-15T16:37:48.1775830Z   INPUT_DAFNY-VERSION: 4.2.0
2024-07-15T16:37:48.1775990Z ##[endgroup]
2024-07-15T16:37:48.2328720Z node:internal/modules/cjs/loader:1031
2024-07-15T16:37:48.2329140Z   throw err;
2024-07-15T16:37:48.2329310Z   ^
2024-07-15T16:37:48.2329410Z 
2024-07-15T16:37:48.2330660Z Error: Cannot find module '/private/tmp/codebuild/output/src962/src/a951722d_5a9e_4668_ab99_68c59d804d36/actions-runner/_work/aws-cryptographic-material-providers-library/aws-cryptographic-material-providers-library/dist/index.js'
2024-07-15T16:37:48.2331720Z     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1028:15)
2024-07-15T16:37:48.2332170Z     at Function.Module._load (node:internal/modules/cjs/loader:873:27)
2024-07-15T16:37:48.2333260Z     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
2024-07-15T16:37:48.2333710Z     at node:internal/main/run_main_module:22:47 {
2024-07-15T16:37:48.2333990Z   code: 'MODULE_NOT_FOUND',
2024-07-15T16:37:48.2334180Z   requireStack: []
2024-07-15T16:37:48.2334350Z }
2024-07-15T16:37:48.2340470Z ##[error]Process completed with exit code 1.
```

So the fix *should* be to change the invocation to `node $GITHUB_ACTION_PATH/dist/index.js` following [this](https://stackoverflow.com/questions/66630437/composite-github-action-automatically-cd-into-actions-directory)